### PR TITLE
fix: use array for CLI args to avoid quoting errors in deploy script

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 # Set up the private key if we have one.
-if [[ -n "$SSH_PRIVATE_KEY" ]]; then
+if [[ -n "${SSH_PRIVATE_KEY:-}" ]]; then
 	eval "$(ssh-agent -s)"
 	echo "$SSH_PRIVATE_KEY" | tr -d '\r' | ssh-add - >/dev/null
 fi
@@ -10,13 +11,25 @@ fi
 mkdir -p ~/.ssh && chmod 0700 ~/.ssh
 cat "${KNOWN_HOSTS_PATH}" >>~/.ssh/known_hosts
 
+# Set the remote
 platform project:set-remote "${PLATFORM_PROJECT_ID}"
-[[ "$ENVIRONMENT_NAME" == "" ]] && ENVIRONMENT_NAME="$GITHUB_REF_NAME"
-PLATFORM_OPTS="-vv --activate --target $ENVIRONMENT_NAME"
-if [[ -n "$FORCE_PUSH" ]]; then
-	PLATFORM_OPTS="$PLATFORM_OPTS --force"
+
+# Fallback for ENVIRONMENT_NAME
+[[ -z "${ENVIRONMENT_NAME:-}" ]] && ENVIRONMENT_NAME="$GITHUB_REF_NAME"
+
+# Build CLI options safely
+PLATFORM_OPTS=(-vv --activate --target "$ENVIRONMENT_NAME")
+
+if [[ -n "${FORCE_PUSH:-}" ]]; then
+	PLATFORM_OPTS+=("--force")
 fi
-if [[ -n "$PARENT_ENVIRONMENT_NAME" ]]; then
-	PLATFORM_OPTS="$PLATFORM_OPTS --parent $PARENT_ENVIRONMENT_NAME"
+
+if [[ -n "${PARENT_ENVIRONMENT_NAME:-}" ]]; then
+	PLATFORM_OPTS+=("--parent" "$PARENT_ENVIRONMENT_NAME")
 fi
-platform push "${PLATFORM_OPTS}"
+
+# Debug: print args for confirmation
+echo "platform push ${PLATFORM_OPTS[*]}"
+
+# Run the push command
+platform push "${PLATFORM_OPTS[@]}"


### PR DESCRIPTION
This PR fixes issue #80 