### PR TITLE
ci(linter): unset persist-credentials for checkout action

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Node.js
         id: setup-node


### PR DESCRIPTION
The `persist-credentials` option for the `actions/checkout` action defaults to `true`, which can lead to unexpected behavior when switching between different repository checks. Setting it to `false` ensures that credentials are not persisted across different checks, promoting a more secure and predictable CI environment.
