### PR TITLE
fix: respect environment-name input during cleanup

### DIFF
--- a/__tests__/clean-pr-env.test.ts
+++ b/__tests__/clean-pr-env.test.ts
@@ -138,6 +138,34 @@ describe('cleanPrEnv', () => {
     expect(core.endGroup).toHaveBeenCalled()
   })
 
+  it('should use the environment-name input when provided', async () => {
+    const mockEnvResult = getTestEnvironment('active', 'pr-123')
+    getEnvironmentMock.mockResolvedValue(mockEnvResult)
+    github.context.payload.pull_request = { number: 123 }
+    core.getInput.mockImplementation(name => {
+      switch (name) {
+        case 'project-id':
+          return 'project-id'
+        case 'cli-token':
+          return 'cli-token'
+        case 'environment-name':
+          return 'pr-123'
+        default:
+          return ''
+      }
+    })
+
+    await cleanPrEnv()
+
+    expect(getEnvironmentMock).toHaveBeenCalledWith('project-id', 'pr-123')
+    expect(mockEnvResult.deactivate).toHaveBeenCalled()
+    expect(mockEnvResult.delete).toHaveBeenCalled()
+    expect(core.info).toHaveBeenCalledWith(
+      `pr-123 environment deleted successfully.`
+    )
+    expect(core.endGroup).toHaveBeenCalled()
+  })
+
   it('should handle error during getEnvironment call', async () => {
     const errorMessage = 'Failed to get environment details'
     getEnvironmentMock.mockRejectedValue(new Error(errorMessage))

--- a/dist/index.js
+++ b/dist/index.js
@@ -90095,7 +90095,7 @@ async function cleanPrEnv() {
     }
     const client = await getCliClient(getInput('cli-token'));
     // Get env details
-    const prRef = `${prNumber}/merge`;
+    const prRef = getInput('environment-name') || `${prNumber}/merge`;
     let envResult;
     try {
         envResult = await client.getEnvironment(getInput('project-id'), encodeURIComponent(prRef));

--- a/package-lock.json
+++ b/package-lock.json
@@ -9502,20 +9502,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/rollup/node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
-      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",

--- a/src/clean-pr-env.ts
+++ b/src/clean-pr-env.ts
@@ -18,7 +18,7 @@ export async function cleanPrEnv(): Promise<void> {
   const client = await getCliClient(core.getInput('cli-token'))
 
   // Get env details
-  const prRef = `${prNumber}/merge`
+  const prRef = core.getInput('environment-name') || `${prNumber}/merge`
   let envResult: Awaited<ReturnType<typeof client.getEnvironment>> | undefined
   try {
     envResult = await client.getEnvironment(


### PR DESCRIPTION

Fixes #195

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test coverage for using an explicit environment identifier instead of deriving from the PR.

* **New Features**
  * Action now accepts a custom environment identifier input; when provided, cleanup targets that environment, otherwise it falls back to the default PR-based naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->